### PR TITLE
Format property feature

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -14,14 +14,16 @@
 <body>
 
   <!-- Single feed query -->
-  <google-feeds feed="http://www.engadget.com/rss-full.xml">
-  </google-feeds>
+  <google-feeds feed="http://www.engadget.com/rss-full.xml"></google-feeds>
 
   <!-- Find feeds -->
   <google-feeds query="gadgets" id="feedSearch"></google-feeds>
 
   <!-- Multiple feeds query -->
   <google-feeds id="feeder"></google-feeds>
+
+  <!-- format feeds -->
+  <google-feeds id="feedFormat" feed="http://www.engadget.com/rss-full.xml" format="xml"></google-feeds>
 
   <div></div>
   <script>
@@ -36,8 +38,9 @@
     });
 
     var feeder = document.getElementById("feeder");
+
     feeder.feeds = ['https://news.ycombinator.com/rss',
-    'http://feeds.bbci.co.uk/news/rss.xml'];
+      'http://feeds.bbci.co.uk/news/rss.xml'];
   </script>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,9 @@
 
   <!-- format feeds -->
   <google-feeds id="feedFormat" feed="http://www.engadget.com/rss-full.xml" format="xml"></google-feeds>
+  
+  <!-- format feed not correct then json is retrieved -->
+  <google-feeds id="feedFormat" feed="http://www.engadget.com/rss-full.xml" format="xmls"></google-feeds>
 
   <div></div>
   <script>

--- a/google-feeds.html
+++ b/google-feeds.html
@@ -235,11 +235,13 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
     _format: function() {
       switch(this.format) {
         case 'json':
+        default:
           return google.feeds.Feed.JSON_FORMAT;
         case 'xml':
           return google.feeds.Feed.XML_FORMAT;
         case 'mixed':
           return google.feeds.Feed.MIXED_FORMAT;
+
       }
     }
 

--- a/google-feeds.html
+++ b/google-feeds.html
@@ -106,7 +106,16 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
       loading: {
         type: Boolean,
         notify: true
-      }
+      },
+
+      /**
+       * Format the data is returned. json(default)|xml|mixed
+       * Only applies for one feed.
+       */
+       format: {
+         type: String,
+         value: 'json'
+       }
     },
 
     attached: function() {
@@ -126,6 +135,7 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
 
     _fetchFeeds: function() {
       var feed = new google.feeds.Feed(this.feed);
+      feed.setResultFormat(this._format());
       feed.includeHistoricalEntries(); // tell the API we want to have old entries too
       feed.setNumEntries(this.count); // we want this maximum number of entries, if they exist
       feed.load(this._fetchFeedsDone.bind(this));
@@ -137,8 +147,13 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
         this.results = {};
         this.fire('google-feeds-error', {status: results.status});
       } else {
-        this.results = results.feed;
-        this.fire('google-feeds-response', {feed: results.feed});
+        if ( results.m === google.feeds.Feed.MIXED_FORMAT ) {
+          results.feed.xmlDocument = results.xmlDocument;
+        }
+
+        this.results = results.m === google.feeds.Feed.XML_FORMAT ? results.xmlDocument : results.feed;
+
+        this.fire('google-feeds-response', {feed: results.feed || results.xmlDocument});
       }
     },
 
@@ -214,6 +229,17 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
         if (callback) {
           this._feedsCallbacks.push(callback);
         }
+      }
+    },
+
+    _format: function() {
+      switch(this.format) {
+        case 'json':
+          return google.feeds.Feed.JSON_FORMAT;
+        case 'xml':
+          return google.feeds.Feed.XML_FORMAT;
+        case 'mixed':
+          return google.feeds.Feed.MIXED_FORMAT;
       }
     }
 

--- a/google-feeds.html
+++ b/google-feeds.html
@@ -147,13 +147,12 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
         this.results = {};
         this.fire('google-feeds-error', {status: results.status});
       } else {
-        if ( results.m === google.feeds.Feed.MIXED_FORMAT ) {
+        if (results.m === google.feeds.Feed.MIXED_FORMAT) {
           results.feed.xmlDocument = results.xmlDocument;
         }
 
         this.results = results.m === google.feeds.Feed.XML_FORMAT ? results.xmlDocument : results.feed;
-
-        this.fire('google-feeds-response', {feed: results.feed || results.xmlDocument});
+        this.fire('google-feeds-response', {feed: this.results});
       }
     },
 
@@ -234,14 +233,13 @@ Exposes [Google Feeds API](https://developers.google.com/feed/)
 
     _format: function() {
       switch(this.format) {
-        case 'json':
-        default:
-          return google.feeds.Feed.JSON_FORMAT;
         case 'xml':
           return google.feeds.Feed.XML_FORMAT;
         case 'mixed':
           return google.feeds.Feed.MIXED_FORMAT;
-
+        case 'json':
+        default:
+          return google.feeds.Feed.JSON_FORMAT;
       }
     }
 


### PR DESCRIPTION
Hello,
I'm using this component in order to fetch podcast feeds and I'm seeing the json returned does not contain all the info which comes in the original xml.

I've seen in the Feeds API you can set the format result using the method _.setResultFormat(format)_ so  I've forked the reposiroty and included the _format_ property in the component with the options formats given by the API:

> .setResultFormat(format) sets the result format to one of google.feeds.Feed.JSON_FORMAT, google.feeds.Feed.XML_FORMAT, or google.feeds.Feed.MIXED FORMAT. By default, the Feed class uses the JSON format.  

If you like this new feature you just can try it and add it to the component if you happy with it.
Anything you like to know something more you can contact me.

Regards.
