### PR TITLE
from polymer to Polymer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^1.0.0",
     "google-apis": "GoogleWebComponents/google-apis#^1.0",
     "iron-jsonp-library": "PolymerElements/iron-jsonp-library#^1.0.0"
   },


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "Polymer" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.